### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/helloci.yml
+++ b/.github/workflows/helloci.yml
@@ -41,7 +41,7 @@ jobs:
           path: main.go
 
       - name: Publish to Registry
-        uses: elgohr/Publish-Docker-Github-Action@master
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: ccr.ccs.tencentyun.com/marmotedu/helloci:beta  # docker image 的名字
           username: ${{ secrets.DOCKER_USERNAME}} # 用户名


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore